### PR TITLE
✨ feat: Access Token 자동 재발급 시스템 구현

### DIFF
--- a/vibeapp/public/routes.py
+++ b/vibeapp/public/routes.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from vibeapp.config import Config
 from vibeapp.extensions import db
 from vibeapp.models.user import User
+from vibeapp.utils import refresh_access_token
 
 public_bp = Blueprint(
     "public",

--- a/vibeapp/utils/__init__.py
+++ b/vibeapp/utils/__init__.py
@@ -1,0 +1,1 @@
+from vibeapp.utils.token_utils import refresh_access_token

--- a/vibeapp/utils/auth_utils.py
+++ b/vibeapp/utils/auth_utils.py
@@ -1,0 +1,14 @@
+from flask import session
+
+from vibeapp.models.user import User
+
+def get_current_user():
+    user_data = session.get("user")
+    if not user_data:
+        return None
+    
+    spotify_id = user_data.get("spotify_id")
+    if not spotify_id:
+        return None
+    
+    return User.query.filter_by(spotify_id=spotify_id).first()

--- a/vibeapp/utils/token_utils.py
+++ b/vibeapp/utils/token_utils.py
@@ -1,0 +1,40 @@
+import requests
+from datetime import datetime, timezone, timedelta
+
+from vibeapp.config import Config
+from vibeapp.models.user import User
+from vibeapp.extensions import db
+from vibeapp.config import Config
+
+def refresh_access_token(user: User) -> str:
+    if user.token_expire_at and user.token_expire_at > datetime.now(timezone.utc):
+        return user.access_token # 아직 유효함
+    
+    if not user.refresh_token:
+        raise ValueError("Refresh token is missing")
+    
+    token_url = "https://accounts.spotify.com/api/token"
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": user.refresh_token,
+        "client_id": Config.CLIENT_ID,
+        "client_secret": Config.CLIENT_SECRET,
+    }
+    
+    res = requests.post(token_url, data=payload)
+    if res.status_code != 200:
+        raise RuntimeError("Token refresh failed")
+    
+    res_data = res.json()
+    user.access_token = res_data.get("access_token")
+    
+    new_refresh_token = res_data.get("refresh_token")
+    if new_refresh_token:
+        user.refresh_token = new_refresh_token
+        
+    expires_in = res_data.get("expires_in", 3600)
+    user.token_expire_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    
+    db.session.commit()
+    
+    return user.access_token

--- a/vibeapp/utils/token_utils.py
+++ b/vibeapp/utils/token_utils.py
@@ -7,7 +7,8 @@ from vibeapp.extensions import db
 from vibeapp.config import Config
 
 def refresh_access_token(user: User) -> str:
-    if user.token_expire_at and user.token_expire_at > datetime.now(timezone.utc):
+    expire_at = user.token_expire_at
+    if expire_at and expire_at.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc):
         return user.access_token # 아직 유효함
     
     if not user.refresh_token:


### PR DESCRIPTION
### 주요 변경 사항

- Access Token 만료 시 Refresh Token을 사용해 새 토큰을 자동으로 발급받는 로직 구현
- User 모델에 `token_expire_at` 필드 추가하여 만료 시각 저장
- 토큰 만료 여부를 확인한 후, 필요한 경우에만 재발급 요청 수행
- Spotify API 응답에 새로운 `refresh_token`이 포함되면 DB에 반영
- refresh 로직은 `utils/token_utils.py`의 `refresh_access_token(user)` 함수로 구현
- datetime 처리 시 offset-naive vs offset-aware 오류 수정
- 현재 로그인한 사용자 정보를 DB에서 조회하는 유틸 함수 추가

---

### 관련 커밋

- `🔐feat: refresh token으로 access token 재발급하는 유틸 함수 추가`
- `♻️refactor: Access Token 자동 갱신 및 refresh_token 갱신 처리 로직 추가`
- `✨feat: 현재 로그인한 사용자 정보를 DB에서 조회하는 유틸 함수 추가`
- `🐛fix: naive/aware datetime 비교 오류 수정`

---

### 변경 파일 요약

- `vibeapp/utils/token_utils.py` - 토큰 갱신 로직
- `vibeapp/models/user.py` - 만료 시간 필드 추가
- `vibeapp/utils/user_utils.py` - 사용자 조회 함수
- 기타: datetime 처리 개선

---

### 확인 사항

- [x] Access Token 만료 시 정상적으로 재발급되는지 확인함
- [x] 새로운 Refresh Token이 발급되면 DB에 저장됨
- [x] 만료 시각은 UTC 기준으로 저장되고 오류 없이 비교됨
- [x] naive/aware datetime TypeError 발생하지 않음
- [x] 기존 로그인/세션 흐름에 영향 없음

---

### 기타 참고 사항

- Token 만료 시 사용자가 인지하지 못한 채 백그라운드에서 재발급되는 구조(Slient Refresh)로 설계
